### PR TITLE
Bump bootstrap from 3.0.0 to 3.4.1 in /Sociatis

### DIFF
--- a/Sociatis/packages.config
+++ b/Sociatis/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr" version="3.4.1.9004" targetFramework="net452" />
-  <package id="bootstrap" version="3.0.0" targetFramework="net452" />
+  <package id="bootstrap" version="3.4.1" targetFramework="net452" />
   <package id="BuildWebCompiler" version="1.11.326" targetFramework="net452" />
   <package id="DataTables.AspNet.Core" version="2.0.2" targetFramework="net452" />
   <package id="DataTables.AspNet.Mvc5" version="2.0.2" targetFramework="net452" />


### PR DESCRIPTION
Bumps bootstrap from 3.0.0 to 3.4.1.

Signed-off-by: dependabot[bot] <support@github.com>